### PR TITLE
Add mechanics of materials OER

### DIFF
--- a/104/README.md
+++ b/104/README.md
@@ -1,1 +1,10 @@
+# Mechanics of Materials Open Educational Resources
+
+Below are links to free, openly licensed materials for studying mechanics of materials.
+
+- [Mechanics of Materials](https://ocw.mit.edu/courses/3-032-mechanics-of-materials-fall-1999/) by David Roylance (MIT OpenCourseWare, CC BY-NC-SA)
+- [Solid Mechanics](https://ocw.mit.edu/courses/2-001-solid-mechanics-fall-2006/) MIT OpenCourseWare (CC BY-NC-SA)
+- [Mechanics of Materials](https://eng.libretexts.org/Bookshelves/Mechanics_of_Materials) (LibreTexts, CC BY-NC-SA)
+- [Engineering Mechanics: Statics](https://openstax.org/details/books/statics) (OpenStax, CC BY 4.0)
+- [Engineering Mechanics: Dynamics](https://openstax.org/details/books/dynamics) (OpenStax, CC BY 4.0)
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
 # AIPBL
-Repository of Open Source Materials for EEE 161, ENGR 104L, CIS 307
+Repository of Open Source Materials for EEE 161, ENGR 104L, and CIS 307
 
 ## Directory Overview
 
 - `161/` - Links to open educational resources for electromagnetics (EEE 161)
+- `104/` - Links to open educational resources for mechanics of materials (ENGR 104L)
+- `307/` - Placeholder for CIS 307 materials
 - `OER_EEE161/` - Placeholder for additional course materials
 
 
 
 ## Purpose
-This repository aims to collect quality open educational resources (OERs) on electromagnetics. By gathering freely available lectures, notes, and problem sets in one place, we hope to support students and instructors looking for accessible learning materials.
+This repository collects quality open educational resources (OERs) for several engineering courses. By gathering freely available lectures, notes, and problem sets in one place, we hope to support students and instructors looking for accessible learning materials across subjects such as electromagnetics and mechanics of materials.
 
 ## Contributing
-Contributions are welcome! To add a new resource, fork this repository, append your link to the `161/README.md` file, and submit a pull request describing the addition.
+Contributions are welcome! To add a new resource, fork this repository, append your link to the appropriate course README (for example `161/README.md` or `104/README.md`), and submit a pull request describing the addition.
 
 ## License
 Material in this repository is released under the [CC0 1.0 Universal](LICENSE) license.


### PR DESCRIPTION
## Summary
- add OER links for mechanics of materials
- document 104 and 307 directories in the repo overview
- broaden repo purpose and contribution guidelines

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840f98143588327a5c23d4c6b1b0fce