### PR TITLE
Add Cal Poly Humboldt LibreTexts link to 104 README

### DIFF
--- a/104/README.md
+++ b/104/README.md
@@ -35,6 +35,9 @@ Mechanics of Materials / Strength of Materials lecture + lab (or lab-like analys
 - Modules (PDF notes):
   - [https://ocw.mit.edu/courses/3-11-mechanics-of-materials-fall-1999/pages/modules/](https://ocw.mit.edu/courses/3-11-mechanics-of-materials-fall-1999/pages/modules/)
 
+### Mechanics and Science of Materials (Cal Poly Humboldt) — LibreTexts
+- [https://eng.libretexts.org/Courses/California_State_Polytechnic_University_Humboldt/Mechanics_and_Science_of_Materials](https://eng.libretexts.org/Courses/California_State_Polytechnic_University_Humboldt/Mechanics_and_Science_of_Materials)
+
 ### MIT OCW 1.050 Solid Mechanics — OCW Creative Commons
 - [https://ocw.mit.edu/courses/1-050-solid-mechanics-fall-2004/](https://ocw.mit.edu/courses/1-050-solid-mechanics-fall-2004/)
 


### PR DESCRIPTION
### Motivation
- Provide an additional OER for the Mechanics of Materials collection by adding the Cal Poly Humboldt LibreTexts resource to the curated list.
- Keep the README's resource list comprehensive and consistent with other LibreTexts and OCW links.

### Description
- Updated the file `104/README.md` to include a new entry titled "Mechanics and Science of Materials (Cal Poly Humboldt) — LibreTexts".
- Inserted the external link `https://eng.libretexts.org/Courses/California_State_Polytechnic_University_Humboldt/Mechanics_and_Science_of_Materials` formatted to match existing entries.
- Change is documentation-only and limited to the `104` directory.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bfba46a0083278a45ad10016fe495)